### PR TITLE
[#51] mypageLayout 메뉴바 수정 및 footer 붙는 문제 수정 

### DIFF
--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -2,6 +2,7 @@
   background-color: var(--nomad_black);
   width: 100%;
   height: 16rem;
+  padding: 3.2rem 0 10.5rem;
 }
 
 .content {
@@ -10,5 +11,4 @@
   justify-content: center;
   font-family: Arial;
   font-size: 1.6rem;
-  padding-top: 3.2rem;
 }

--- a/src/components/MyPage/MyPageLayout.module.css
+++ b/src/components/MyPage/MyPageLayout.module.css
@@ -5,6 +5,7 @@
   gap: 2.4rem;
   justify-content: center;
   margin-top: 7.2rem;
+  padding-bottom: 25rem;
 
   @media tablet {
     gap: 1.6rem;

--- a/src/components/MyPage/ProfileMenuBox.module.css
+++ b/src/components/MyPage/ProfileMenuBox.module.css
@@ -45,10 +45,19 @@
   line-height: 2.6rem;
 }
 
+.subTitle {
+  color: #969696;
+  font-weight: 400;
+}
+
 .active {
   background-color: var(--greenCE);
 }
 
 .active > .menuItemTitle {
   color: var(--nomad_black);
+}
+
+.menuItem:hover .subTitle {
+  display: none;
 }

--- a/src/components/MyPage/ProfileMenuBox.tsx
+++ b/src/components/MyPage/ProfileMenuBox.tsx
@@ -36,11 +36,31 @@ const MENU_LIST = [
 
 function ProfileMenuBox() {
   const router = useRouter();
-  const [isSelected, setIsSelected] = useState(MENU_LIST.find((e) => e.link === router.pathname)?.title);
+  const { pathname } = router;
+  const [isSelected, setIsSelected] = useState(
+    pathname === '/mypage/reservations/[id]' ? '예약 내역' : MENU_LIST.find((e) => e.link === router.pathname)?.title,
+  );
 
   const handleMenuItem = (item: { title: string; link: string }) => {
     setIsSelected(item.title);
     router.push(item.link);
+  };
+
+  console.log(router);
+
+  const renderTitle = (title: string) => {
+    const result = [];
+    if (router.pathname === '/mypage/reservations/[id]') {
+      result.push(
+        <>
+          {title} <span className={styles.subTitle}>- 예약 상세</span>
+        </>,
+      );
+    } else {
+      result.push(<>{title}</>);
+    }
+
+    return result;
   };
 
   return (
@@ -55,7 +75,7 @@ function ProfileMenuBox() {
               onClick={() => handleMenuItem(e)}
             >
               {e.title === isSelected ? e.activeSrc : e.src}
-              <div className={styles.menuItemTitle}>{e.title}</div>
+              <div className={styles.menuItemTitle}>{e.title === '예약 내역' ? renderTitle(e.title) : e.title}</div>
             </div>
           );
         })}

--- a/src/components/MyPage/ProfileMenuBox.tsx
+++ b/src/components/MyPage/ProfileMenuBox.tsx
@@ -46,8 +46,6 @@ function ProfileMenuBox() {
     router.push(item.link);
   };
 
-  console.log(router);
-
   const renderTitle = (title: string) => {
     const result = [];
     if (router.pathname === '/mypage/reservations/[id]') {

--- a/src/components/common/Navbar.module.css
+++ b/src/components/common/Navbar.module.css
@@ -7,6 +7,7 @@
   display: flex;
   justify-content: space-around;
   align-items: center;
+  padding: 1.9rem 0;
 }
 
 .logoWrapper {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -44,7 +44,7 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
         <HydrationBoundary state={pageProps.dehydratedState}>
           <div className="root">
             {!router.pathname.includes('sign') && <Navbar />}
-            {getLayout(<Component {...pageProps} />)}
+            <div className="content">{getLayout(<Component {...pageProps} />)}</div>
             {!router.pathname.includes('sign') && <Footer />}
           </div>
         </HydrationBoundary>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -42,9 +42,11 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
       </Head>
       <QueryClientProvider client={queryClient}>
         <HydrationBoundary state={pageProps.dehydratedState}>
-          {!router.pathname.includes('sign') && <Navbar />}
-          {getLayout(<Component {...pageProps} />)}
-          {!router.pathname.includes('sign') && <Footer />}
+          <div className="root">
+            {!router.pathname.includes('sign') && <Navbar />}
+            {getLayout(<Component {...pageProps} />)}
+            {!router.pathname.includes('sign') && <Footer />}
+          </div>
         </HydrationBoundary>
         <div style={{ fontSize: '16px' }}>
           <ReactQueryDevtools initialIsOpen={false} />

--- a/src/pages/mypage/reservations/[id]/index.tsx
+++ b/src/pages/mypage/reservations/[id]/index.tsx
@@ -1,0 +1,9 @@
+import MyPageLayout from '@/components/MyPage/MyPageLayout';
+import { ReactElement } from 'react';
+
+const Id = () => {
+  return <div>a</div>;
+};
+export default Id;
+
+Id.getLayout = (page: ReactElement) => <MyPageLayout>{page}</MyPageLayout>;

--- a/src/pages/mypage/reservations/index.tsx
+++ b/src/pages/mypage/reservations/index.tsx
@@ -1,0 +1,11 @@
+import MyPageLayout from '@/components/MyPage/MyPageLayout';
+import { useRouter } from 'next/router';
+import { ReactElement } from 'react';
+
+const Id = () => {
+  const router = useRouter();
+  return <div onClick={() => router.push('/mypage/reservations/3')}>a</div>;
+};
+export default Id;
+
+Id.getLayout = (page: ReactElement) => <MyPageLayout>{page}</MyPageLayout>;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -20,7 +20,16 @@ button {
   cursor: pointer;
 }
 
+#__next {
+  height: 100%;
+}
+
 .root {
   display: flex;
   flex-direction: column;
+  height: 100%;
+}
+
+.content {
+  flex: 1;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,3 +19,8 @@ a,
 button {
   cursor: pointer;
 }
+
+.root {
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
## 🕹️ 작업 내용

- [x] 예약 상세페이지의 경우 메뉴바의 예약 내역 -> 예약 내역 - 예약 상세  
- [x] 예약 메뉴에 hover시 예약 상세 사라짐
- [x] 예약 상세페이지도 동일하게 예약 메뉴 클릭 시 예약 메뉴로 이동

## 📋 리뷰 포인트

- 임시로 reservations 페이지, reservations/[id] 페이지 만들어놨습니다. (머지되기 전 삭제)
- mypage/reservations 에서 'a' 클릭 시 mypage/reservations/[id]로 이동합니다. 이 페이지에서 메뉴 확인가능합니다. 
- footer 붙는 문제 수정했습니다.

## 🔮 기타 사항
<img width="1512" alt="스크린샷 2024-01-29 오후 7 44 27" src="https://github.com/TripTripNow/TodayTrip/assets/77039033/b823862e-4424-4156-aaf2-3c27bb89c5fe">
