### PR TITLE
[#140] 로그인, 회원가입, 내 정보 페이지 2차 QA

### DIFF
--- a/src/components/Input/CheckboxInput.tsx
+++ b/src/components/Input/CheckboxInput.tsx
@@ -14,7 +14,14 @@ function CheckboxInput({ control, name }: CheckboxInputProps) {
 
   return (
     <label className={styles.checkboxInput} htmlFor={field.name}>
-      <input type="checkbox" id={field.name} name={field.name} value={field.value} onChange={field.onChange} />
+      <input
+        type="checkbox"
+        id={field.name}
+        name={field.name}
+        checked={field.value}
+        value={field.value}
+        onChange={field.onChange}
+      />
       비밀번호 표시
     </label>
   );

--- a/src/components/MyPage/Activities/Add/ReservationTime.tsx
+++ b/src/components/MyPage/Activities/Add/ReservationTime.tsx
@@ -81,6 +81,7 @@ function ReservationTime({ name, control, setValue, getValues }: ReservationTime
         endTime: endTimeItem.title,
       },
     ]);
+    toast.success('체험시간이 추가되었습니다.');
   };
 
   // 삭제하는 부분

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -58,7 +58,7 @@ function Navbar() {
   };
 
   const handleAlarmModalClick = () => {
-    setIsModalOpen((prev) => !prev);
+    if (!isFetching) setIsModalOpen((prev) => !prev);
   };
 
   useEffect(() => {
@@ -93,7 +93,7 @@ function Navbar() {
                   <AlarmIcon alt="알람 아이콘" className={styles.alarmIcon} />
                   {totalCount > 0 && <RedEllipse alt="알람이 존재함을 알려주는 아이콘" className={styles.isEllipse} />}
                 </button>
-                {isModalOpen && !isFetching && (
+                {isModalOpen && (
                   <AlarmModal
                     setIsModalOpen={setIsModalOpen}
                     targetRef={targetRef}

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -22,7 +22,7 @@ function Navbar() {
 
   const { data: userData } = useSession();
 
-  const { data, fetchNextPage } = useInfiniteQuery({
+  const { data, fetchNextPage, isFetching } = useInfiniteQuery({
     queryKey: [QUERY_KEYS.myNotifications],
     queryFn: ({ pageParam }) => getMyNotifications(pageParam),
     initialPageParam: 0,
@@ -93,7 +93,7 @@ function Navbar() {
                   <AlarmIcon alt="알람 아이콘" className={styles.alarmIcon} />
                   {totalCount > 0 && <RedEllipse alt="알람이 존재함을 알려주는 아이콘" className={styles.isEllipse} />}
                 </button>
-                {isModalOpen && (
+                {isModalOpen && !isFetching && (
                   <AlarmModal
                     setIsModalOpen={setIsModalOpen}
                     targetRef={targetRef}

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -16,6 +16,7 @@ import { SOCIAL_EMAIL_CONTENT } from '@/constants/user';
 import toast from 'react-hot-toast';
 import HeadMeta from '@/components/HeadMeta/HeadMeta';
 import { META_TAG } from '@/constants/metaTag';
+import CheckboxInput from '@/components/Input/CheckboxInput';
 
 interface MyPageProps {
   userData: GetUsersMeRes;
@@ -44,6 +45,7 @@ function MyPage({ userData, type }: MyPageProps) {
       mypageEmail: type === 'credentials' ? userData.email : SOCIAL_EMAIL_CONTENT[type],
       mypagePassword: '',
       mypagePasswordCheck: '',
+      checkbox: false,
     },
   });
 
@@ -52,6 +54,8 @@ function MyPage({ userData, type }: MyPageProps) {
   const { getValues } = useFormContext();
   const queryClient = useQueryClient();
   const { update } = useSession();
+
+  const isPasswordVisible = methods.watch('checkbox');
 
   const patchUserMeMutation = useMutation({
     mutationFn: (data: PatchUsersMeReq) => patchUsersMe(data),
@@ -113,7 +117,7 @@ function MyPage({ userData, type }: MyPageProps) {
             control={control}
             label={'비밀번호'}
             placeholder={'8자 이상 입력해 주세요'}
-            type={'password'}
+            type={isPasswordVisible ? 'text' : 'password'}
             isDisabled={type !== 'credentials'}
           />
           <Input
@@ -121,9 +125,10 @@ function MyPage({ userData, type }: MyPageProps) {
             control={control}
             label={'비밀번호 확인'}
             placeholder={'비밀번호를 한번 더 입력해 주세요'}
-            type={'password'}
+            type={isPasswordVisible ? 'text' : 'password'}
             isDisabled={type !== 'credentials'}
           />
+          {type === 'credentials' && <CheckboxInput control={control} name="checkbox" />}
         </div>
       </form>
     </>


### PR DESCRIPTION
## 🕹️ 작업 내용

- [x] 로그인 실패 후 비밀번호 표시 초기화 안됨 오류 수정
- [x] 내 정보 페이지 비밀번호 표시 체크박스 추가
- [x] 알림모달 알림 로딩 전 클릭 시 무한스크롤 안됨 오류 수정 => 알림 로딩 전 클릭 막음

## 📋 리뷰 포인트

- 미들웨어에서 로그인 페이지로 이동 시 토스트 띄우는 거는 불가합니다..